### PR TITLE
Add iPhone 6 & 6+ support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cordova-splash
 
-Automatic splash screen generator for Cordova. Create a splash screen (2048x2048) once in the root folder of your Cordova project and use cordova-splash to automatically crop and copy it for all the platforms your project supports (currenty works with iOS and Android).
+Automatic splash screen generator for Cordova. Create a splash screen (2208x2208) once in the root folder of your Cordova project and use cordova-splash to automatically crop and copy it for all the platforms your project supports (currenty works with iOS and Android).
 
 ### Installation
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ var getPlatforms = function (projectName) {
         splashPath : 'platforms/ios/' + projectName + '/Resources/splash/',
         splash : [
             { name : 'Default-568h@2x~iphone.png',    width : 640,  height : 1136 },
+            { name : 'Default-667h.png',              width : 750,  height : 1334 },
+            { name : 'Default-736h.png',              width : 1242,  height : 2208 },
+            { name : 'Default-Landscape-736h.png',    width : 2208,  height : 1242 },
             { name : 'Default-Landscape@2x~ipad.png', width : 2048, height : 1536 },
             { name : 'Default-Landscape~ipad.png',    width : 1024, height : 768 },
             { name : 'Default-Portrait@2x~ipad.png',  width : 1536, height : 2048 },


### PR DESCRIPTION
Add iPhone 6 & 6+ support following the recent release of [Cordova iOS 3.7.0](http://cordova.apache.org/announcements/2014/11/06/cordova-ios-3.7.0.html).
For more info, see [CB-7632](https://issues.apache.org/jira/browse/CB-7632).
This could help fix #2.
