### PR TITLE
Add Android missing screen's size.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,14 @@ var getPlatforms = function (projectName) {
         isAdded : fs.existsSync('platforms/android'),
         splashPath : 'platforms/android/res/',
         splash : [
-            { name : 'drawable/screen.png',       width : 480, height: 640 },
-            { name : 'drawable-hdpi/screen.png',  width : 320, height: 426 },
-            { name : 'drawable-ldpi/screen.png',  width : 320, height: 470 },
-            { name : 'drawable-mdpi/screen.png',  width : 480, height: 640 },
-            { name : 'drawable-xhdpi/screen.png', width : 720, height: 960 },
+            { name : 'drawable-land-ldpi/screen.png',  width : 320, height: 200 },
+            { name : 'drawable-land-mdpi/screen.png',  width : 480, height: 320 },
+            { name : 'drawable-land-hdpi/screen.png',  width : 800, height: 480 },
+            { name : 'drawable-land-xhdpi/screen.png', width : 1280, height: 720 },
+            { name : 'drawable-port-ldpi/screen.png',  width : 200, height: 320 },
+            { name : 'drawable-port-mdpi/screen.png',  width : 320, height: 480 },
+            { name : 'drawable-port-hdpi/screen.png',  width : 480, height: 800 },
+            { name : 'drawable-port-xhdpi/screen.png', width : 720, height: 1280 },
         ]
     });
     // TODO: add all platforms


### PR DESCRIPTION
These new sizes are based on the defaults actually created when adding android as a platform in a cordova project.
I also changed the generated files' path to respect the actual cordova naming convention.
(This should fix #1)
