### PR TITLE
Repair ios splash gen

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var fs     = require('fs');
+var path   = require('path');
 var xml2js = require('xml2js');
 var ig     = require('imagemagick');
 var colors = require('colors');
 var _      = require('underscore');
 var Q      = require('q');
+var wrench = require('wrench');
 
 /**
  * Check which platforms are added to the project and return their splash screen names and sizes
@@ -138,9 +140,19 @@ var getProjectName = function () {
  */
 var generateSplash = function (platform, splash) {
   var deferred = Q.defer();
+  var srcPath = settings.SPLASH_FILE;
+  var platformPath = srcPath.replace(/\.png$/, '-' + platform.name + '.png');
+  if (fs.existsSync(platformPath)) {
+    srcPath = platformPath;
+  }
+  var dstPath = platform.splashPath + splash.name;
+  var dst = path.dirname(dstPath);
+  if (!fs.existsSync(dst)) {
+    wrench.mkdirSyncRecursive(dst);
+  }
   ig.crop({
-    srcPath: settings.SPLASH_FILE,
-    dstPath: platform.splashPath + splash.name,
+    srcPath: srcPath,
+    dstPath: dstPath,
     quality: 1,
     format: 'png',
     width: splash.width,

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
   },
   "homepage": "https://github.com/AlexDisler/cordova-splash",
   "dependencies": {
-    "imagemagick": "^0.1.3",
-    "underscore": "^1.6.0",
     "colors": "^0.6.2",
+    "imagemagick": "^0.1.3",
     "q": "^1.0.1",
+    "underscore": "^1.6.0",
+    "wrench": "^1.5.8",
     "xml2js": "^0.4.3"
   }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | -
| Fixed tickets | This fixes -

This fixes the following error appearing when generating splashes:
```
{ [Error: Command failed: convert: impossible d'ouvrir l'image `platforms/ios/MyApp/Images.xcassets/LaunchImage.launchimage/Default-Portrait~iphone.png': No such file or directory @ error/blob.c/OpenBlob/2701.
convert: WriteBlob Failed `platforms/ios/MyApp/Images.xcassets/LaunchImage.launchimage/Default-Portrait~iphone.png' @ error/png.c/MagickPNGErrorHandler/1630.
] timedOut: false, killed: false, code: 1, signal: null }
```
I copied changes made to https://github.com/AlexDisler/cordova-icon :)