### PR TITLE
add ability to specify output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project [will be documented](http://keepachangelog.com/) in this file.
 This project *tries to* adhere to [Semantic Versioning](http://semver.org/).
 
+## [0.7.0] - 2016-14-17
+
+- uses config/res as the default folder to persist generated files (not backwards compatible)
+- Add --help option
+- Ability to specify output path 
+- Backwards-compatibility mode to use platforms path instead of new defaults (-c)
+
 ## [0.5.1] - 2016-03-11
 - iOS: Get back sizes from previous version of the repo (eb65d2d)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Automatic splash screen generator for Cordova. Create a splash screen (2208x2208
 Create a `splash.png` file in the root folder of your cordova project and run:
 
     $ cordova-splash
+    
+You may specify the output path and directory as follows:
+
+    # output to path/to/res/screen
+    $ cordova-splash -p path/to/res -s screen
+    
+WARNING: If you were using a previous version of cordova-splash and expect the generated files to be in their respective ./platforms
+path, use the compability mode:
+
+    $ cordova-splash -c
+    
+This will override the -p and -s settings.
+    
 
 ### Icons
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var colors = require('colors');
 var _      = require('underscore');
 var Q      = require('q');
 var wrench = require('wrench');
+var optparse = require('optparse');
 
 /**
  * Check which platforms are added to the project and return their splash screen names and sizes
@@ -20,7 +21,7 @@ var getPlatforms = function (projectName) {
     name : 'ios',
     // TODO: use async fs.exists
     isAdded : fs.existsSync('platforms/ios'),
-    splashPath : 'platforms/ios/' + projectName + '/Images.xcassets/LaunchImage.launchimage/',
+    splashPath : (settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/ios/').replace('//', '/'),
     splash : [
       { name: 'Default-568h@2x~iphone.png',           width: 640,  height: 1136 },
       { name: 'Default-667h.png',                     width: 750,  height: 1334 },
@@ -53,7 +54,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'android',
     isAdded : fs.existsSync('platforms/android'),
-    splashPath : 'platforms/android/res/',
+    splashPath : (settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/android/').replace('//', '/'),
     splash : [
       { name: 'drawable-land-ldpi/screen.png',  width: 320,  height: 200  },
       { name: 'drawable-land-mdpi/screen.png',  width: 480,  height: 320  },
@@ -68,7 +69,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'windows',
     isAdded : fs.existsSync('platforms/windows'),
-    splashPath : 'platforms/windows/images/',
+    splashPath :(settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/windows/').replace('//', '/'),
     splash : [
       { name: 'SplashScreen.scale-100.png', width: 620,  height: 300  },
       { name: 'SplashScreen.scale-125.png', width: 775,  height: 375  },
@@ -89,6 +90,8 @@ var getPlatforms = function (projectName) {
 var settings = {};
 settings.CONFIG_FILE = 'config.xml';
 settings.SPLASH_FILE   = 'splash.png';
+settings.RESOURCE_PATH = 'config/res'; // without trailing slash
+settings.SCREEN_DIR = 'screen'; // without slashes
 
 /**
  * @var {Object} console utils
@@ -162,7 +165,7 @@ var generateSplash = function (platform, splash) {
       deferred.reject(err);
     } else {
       deferred.resolve();
-      display.success(splash.name + ' created');
+      display.success(splash.name + ' created [' + dstPath + ']');
     }
   });
   return deferred.promise;
@@ -269,6 +272,31 @@ var configFileExists = function () {
   });
   return deferred.promise;
 };
+
+/**
+ * parse command line options
+ */
+var parseOptions = function() {
+  var switches = [
+     ['-h', '--help', 'Show this help'],
+     ['-p', '--path PATH', 'resource path, defaults to ' + settings.RESOURCE_PATH],
+     ['-s', '--screen DIR', 'screen directory in PATH, defaults to ' + settings.SCREEN_DIR],
+  ];
+  var parser = new optparse.OptionParser(switches);
+  parser.on('help', function() {
+	console.log(parser.toString());
+	process.exit();
+  });
+  parser.on('path', function(opt, path) {
+	settings.RESOURCE_PATH = path;
+  });
+  parser.on('screen', function(opt, path) {
+	settings.SCREEN_DIR = path;
+  });
+  parser.parse(process.argv);
+}
+
+parseOptions();
 
 display.header('Checking Project & Splash');
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var getPlatforms = function (projectName) {
     // TODO: use async fs.exists
     isAdded : fs.existsSync('platforms/ios'),
     splashPath : (settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/ios/').replace('//', '/'),
+    platformSplashPath : 'platforms/ios/' + projectName + '/Images.xcassets/LaunchImage.launchimage/',
     splash : [
       { name: 'Default-568h@2x~iphone.png',           width: 640,  height: 1136 },
       { name: 'Default-667h.png',                     width: 750,  height: 1334 },
@@ -55,6 +56,7 @@ var getPlatforms = function (projectName) {
     name : 'android',
     isAdded : fs.existsSync('platforms/android'),
     splashPath : (settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/android/').replace('//', '/'),
+    platformSplashPath: 'platforms/android/res/',
     splash : [
       { name: 'drawable-land-ldpi/screen.png',  width: 320,  height: 200  },
       { name: 'drawable-land-mdpi/screen.png',  width: 480,  height: 320  },
@@ -70,6 +72,7 @@ var getPlatforms = function (projectName) {
     name : 'windows',
     isAdded : fs.existsSync('platforms/windows'),
     splashPath :(settings.RESOURCE_PATH + '/' + settings.SCREEN_DIR + '/windows/').replace('//', '/'),
+    platformSplashPath: 'platforms/windows/images/',
     splash : [
       { name: 'SplashScreen.scale-100.png', width: 620,  height: 300  },
       { name: 'SplashScreen.scale-125.png', width: 775,  height: 375  },
@@ -92,6 +95,7 @@ settings.CONFIG_FILE = 'config.xml';
 settings.SPLASH_FILE   = 'splash.png';
 settings.RESOURCE_PATH = 'config/res'; // without trailing slash
 settings.SCREEN_DIR = 'screen'; // without slashes
+settings.USE_PLATFORMS_PATH = false; // true to use platforms path
 
 /**
  * @var {Object} console utils
@@ -148,7 +152,8 @@ var generateSplash = function (platform, splash) {
   if (fs.existsSync(platformPath)) {
     srcPath = platformPath;
   }
-  var dstPath = platform.splashPath + splash.name;
+  var dstPath = (settings.USE_PLATFORMS_PATH ? 
+	platform.platformSplashPath : platform.splashPath) + splash.name;
   var dst = path.dirname(dstPath);
   if (!fs.existsSync(dst)) {
     wrench.mkdirSyncRecursive(dst);
@@ -281,6 +286,7 @@ var parseOptions = function() {
      ['-h', '--help', 'Show this help'],
      ['-p', '--path PATH', 'resource path, defaults to ' + settings.RESOURCE_PATH],
      ['-s', '--screen DIR', 'screen directory in PATH, defaults to ' + settings.SCREEN_DIR],
+     ['-c', '--compat', 'uses default path in platforms (backwards compatibility, overrides -p and -i)'],
   ];
   var parser = new optparse.OptionParser(switches);
   parser.on('help', function() {
@@ -292,6 +298,9 @@ var parseOptions = function() {
   });
   parser.on('screen', function(opt, path) {
 	settings.SCREEN_DIR = path;
+  });
+  parser.on('compat', function() {
+	settings.USE_PLATFORMS_PATH = true;
   });
   parser.parse(process.argv);
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "underscore": "^1.6.0",
     "wrench": "^1.5.8",
     "xml2js": "^0.4.3",
-    "optparse": "latest"
+    "optparse": "^1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "q": "^1.0.1",
     "underscore": "^1.6.0",
     "wrench": "^1.5.8",
-    "xml2js": "^0.4.3"
+    "xml2js": "^0.4.3",
+    "optparse": "latest"
   }
 }


### PR DESCRIPTION
now accepts options to specify the output path:

```
# output to path/to/res/screen
$ cordova-splash -p path/to/res -s screen  
```

To improve compabitility with the [cordova splash screen plugin](https://github.com/apache/cordova-plugin-splashscreen), the default output path is now `config/res`.  Note this breaks backwards compatibility. The `--compat` switch preserves the previous behavior, i.e. uses the respective `platforms` path.
