### PR TITLE
Replace use of wrench (which is deprecated) with fs-extra

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
-var fs     = require('fs');
+var fs     = require('fs-extra');
 var path   = require('path');
 var xml2js = require('xml2js');
 var ig     = require('imagemagick');
 var colors = require('colors');
 var _      = require('underscore');
 var Q      = require('q');
-var wrench = require('wrench');
 
 /**
  * Check which platforms are added to the project and return their splash screen names and sizes
@@ -140,7 +139,7 @@ var generateSplash = function (platform, splash) {
   var dstPath = platform.splashPath + splash.name;
   var dst = path.dirname(dstPath);
   if (!fs.existsSync(dst)) {
-    wrench.mkdirSyncRecursive(dst);
+    fs.mkdirsSync(dst);
   }
   ig.crop({
     srcPath: srcPath,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "imagemagick": "^0.1.3",
     "q": "^1.0.1",
     "underscore": "^1.6.0",
-    "wrench": "^1.5.8",
+    "fs-extra": "^0.30.0",
     "xml2js": "^0.4.3"
   }
 }


### PR DESCRIPTION
Using `cordova-splash` on our project and we noticed this:
![cordova-splash -bash 113x40 2016-06-25 20-17-37](https://cloud.githubusercontent.com/assets/3772093/16360391/13051ac2-3b15-11e6-9453-43d174ce52cb.png)

The deprecation message points you to [fs-extra](https://github.com/jprichardson/node-fs-extra). It can indeed create directories, which seems to be the only thing we were using `wrench` for. It also claims to be a drop in replacement for `fs`, which seems to be true upon locally dropping it in and running `cordova-splash`. Hence I suggest we get off of the ticking time bomb :)