### PR TITLE
Updated iOS image path

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var getPlatforms = function (projectName) {
     name : 'ios',
     // TODO: use async fs.exists
     isAdded : fs.existsSync('platforms/ios'),
-    splashPath : 'platforms/ios/' + projectName + '/Resources/splash/',
+    splashPath : 'platforms/ios/' + projectName + '/Images.xcassets/LaunchImage.launchimage/',
     splash : [
       // iPhone
       { name: 'Default~iphone.png',            width: 320,  height: 480  },


### PR DESCRIPTION
This plugin worked great for me in the past on a number of projects, but with a new project using ember-cordova the splash path in the iOS build seems to have changed? Updating the path worked.