### PR TITLE
Optionally use a different splash image for landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ You also can specify manually a location for your `config.xml` or `splash.png`:
 
     $ cordova-splash --config=config.xml --splash=splash.png
 
+In case you want to specify a different splash image for landscape mode create either a `splash-landscape.png` or run: 
+
+    $ cordova-splash --splash-landscape=splash-landscape.png
+
 If you run a old version of Cordova for iOS and you need your files in `/Resources/icons/`, use this option:
 
     $ cordova-splash --xcode-old

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var argv   = require('minimist')(process.argv.slice(2));
 var settings = {};
 settings.CONFIG_FILE = argv.config || 'config.xml';
 settings.SPLASH_FILE = argv.splash || 'splash.png';
+settings.SPLASH_FILE_LANDSCAPE = argv['splash-landscape'] || 'splash-landscape.png';
 settings.OLD_XCODE_PATH = argv['xcode-old'] || false;
 
 /**
@@ -143,6 +144,9 @@ var getProjectName = function () {
 var generateSplash = function (platform, splash) {
   var deferred = Q.defer();
   var srcPath = settings.SPLASH_FILE;
+  if (splash.width > splash.height) {
+    srcPath = settings.SPLASH_FILE_LANDSCAPE;
+  }
   var platformPath = srcPath.replace(/\.png$/, '-' + platform.name + '.png');
   if (fs.existsSync(platformPath)) {
     srcPath = platformPath;
@@ -248,7 +252,15 @@ var validSplashExists = function () {
   fs.exists(settings.SPLASH_FILE, function (exists) {
     if (exists) {
       display.success(settings.SPLASH_FILE + ' exists');
-      deferred.resolve();
+      fs.exists(settings.SPLASH_FILE_LANDSCAPE, function (exists) {
+        if (exists) {
+          display.success(settings.SPLASH_FILE_LANDSCAPE + ' exists');
+        } else {
+          display.error(settings.SPLASH_FILE + ' does not exist, using ' + settings.SPLASH_FILE);
+          settings.SPLASH_FILE_LANDSCAPE = settings.SPLASH_FILE;
+        }
+        deferred.resolve();
+      });
     } else {
       display.error(settings.SPLASH_FILE + ' does not exist');
       deferred.reject();


### PR DESCRIPTION
This PR optionally uses a different splash image for landscape mode. 
Just add a `splash-landscape.png` or set manually with 
```
cordova-splash --splash-landscape=my-splash-landscape.png
```
If such image is not found the default `splash.png` is used.