### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project [will be documented](http://keepachangelog.com/) in this file.
 This project *tries to* adhere to [Semantic Versioning](http://semver.org/).
 
+## [0.9.x] - 
+- Add --help option
+- Ability to specify resource output path via --resource (#27)
+- Ability to specify resource screen output path via --screen (#27)
+- Ability to specify enforce use of platform output via --platform in case default change in the future
+
+- Use optparse instead of minimist
+
 ## [0.9.0] - 2016-08-24
 - Add optional config and icon CLI args (#32)
 - Added Windows SplashScreenPhone sizes (#31)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ The splash screen image should be 2208x2208 px with a center square of about 120
 Create a `splash.png` file in the root folder of your cordova project and run:
 
     $ cordova-splash
+    
+You may specify the output path and directory as follows:
 
+    # output to path/to/res/screen
+    $ cordova-splash -resource path/to/res -screen screen
+    
+This will override the --resource and -screen settings.
+    
 You also can specify manually a location for your `config.xml` or `splash.png`:
 
     $ cordova-splash --config=config.xml --splash=splash.png

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "colors": "^0.6.2",
     "fs-extra": "^0.30.0",
     "imagemagick": "^0.1.3",
-    "minimist": "^1.2.0",
     "q": "^1.0.1",
     "underscore": "^1.6.0",
-    "xml2js": "^0.4.3"
+    "xml2js": "^0.4.3",
+    "optparse": "^1.0.5"
   }
 }


### PR DESCRIPTION
- [x] backport add ability to specify output path on current master #27
    - [x] Add --help option  (#27)
    - [x] Ability to specify resource output path via --resource (#27)
    - [x]  Ability to specify resource screen output path via --screen (#27)
- [x] check resource Path Exists
- [x] Keep existing behavior compare to PR #27 and use USE_PLATFORMS_PATH by default
- [x] Ability to specify enforce use of platform output via --platform in case default change in the future