### PR TITLE
Fix the productName value when attributes are used

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,9 @@ var getProjectName = function () {
         deferred.reject(err);
       }
       var projectName = result.widget.name[0];
+      if (typeof projectName == "object") {
+         projectName = projectName._.trim()
+      }
       deferred.resolve(projectName);
     });
   });


### PR DESCRIPTION
Fix the bad value of productName variable if short attribute has use in name tag
Cordova allow short attribute in name tag. See: https://cordova.apache.org/docs/en/latest/config_ref/#short-name