### PR TITLE
Fix Android Splash path

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ var getPlatforms = function (projectName) {
   platforms.push({
     name : 'android',
     isAdded : fs.existsSync('platforms/android'),
-    splashPath : 'platforms/android/app/src/main/res/',
+    splashPath : 'platforms/android/res/',
     splash : [
       // Landscape
       { name: 'drawable-land-ldpi/screen.png',  width: 320,  height: 200  },


### PR DESCRIPTION
The default splash screen seems to have changed since last version of Cordova (and the associated splash screen plugin).
Updating it in cordova-splash solves the issue